### PR TITLE
Fix token loading, improve withdrawal flushing

### DIFF
--- a/chain-events/src/lib.rs
+++ b/chain-events/src/lib.rs
@@ -34,6 +34,9 @@ pub enum L2Event {
 
     /// Token initialization event.
     L2TokenInitEvent(L2TokenInitEvent),
+
+    /// block seen with a transfer event
+    BlockSeen(u64),
 }
 
 impl From<WithdrawalEvent> for L2Event {

--- a/client/src/base_token.rs
+++ b/client/src/base_token.rs
@@ -1,0 +1,11 @@
+//! ABI wrappers for `L1SharedBridge` contract.
+
+#[allow(missing_docs)]
+pub mod codegen {
+    use ethers::prelude::abigen;
+
+    abigen!(
+        IBaseToken,
+        "$CARGO_MANIFEST_DIR/src/contracts/IBaseToken.json"
+    );
+}

--- a/client/src/contracts/IBaseToken.json
+++ b/client/src/contracts/IBaseToken.json
@@ -1,0 +1,247 @@
+{
+    "abi": [
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "Mint",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "Transfer",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "_l2Sender",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "_l1Receiver",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "_amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "Withdrawal",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "_l2Sender",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "_l1Receiver",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "_additionalData",
+              "type": "bytes"
+            }
+          ],
+          "name": "WithdrawalWithMessage",
+          "type": "event"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "decimals",
+          "outputs": [
+            {
+              "internalType": "uint8",
+              "name": "",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_account",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "_amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "mint",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "name",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "symbol",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "totalSupply",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_from",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "_to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "_amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "transferFromTo",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_l1Receiver",
+              "type": "address"
+            }
+          ],
+          "name": "withdraw",
+          "outputs": [],
+          "stateMutability": "payable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_l1Receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "_additionalData",
+              "type": "bytes"
+            }
+          ],
+          "name": "withdrawWithMessage",
+          "outputs": [],
+          "stateMutability": "payable",
+          "type": "function"
+        }
+      ]
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -24,8 +24,8 @@ use ethers::{
 
 use ethers_log_decode::EthLogDecode;
 use ethtoken::codegen::WithdrawalFilter;
-use l1bridge::codegen::FinalizeWithdrawalCall;
 use l1_shared_bridge::codegen::IL1SharedBridge;
+use l1bridge::codegen::FinalizeWithdrawalCall;
 use l1messenger::codegen::L1MessageSentFilter;
 use l2standard_token::codegen::{BridgeBurnFilter, L1AddressCall};
 use lazy_static::lazy_static;
@@ -63,10 +63,12 @@ pub const DEPLOYER_ADDRESS: Address = H160([
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x80, 0x06,
 ]);
+
+pub mod base_token;
 pub mod contracts_deployer;
 pub mod ethtoken;
-pub mod l1bridge;
 pub mod l1_shared_bridge;
+pub mod l1bridge;
 pub mod l1messenger;
 pub mod l2bridge;
 pub mod l2standard_token;


### PR DESCRIPTION
- Always call `query_past_token_init_events` from `last_seen_l2_token_block` to `latest_block` on `L2EventsListener` start up
    - This fixes missing tokens created between `last_seen_l2_token_block` and `latest_block`
- Use `BaseToken` transfers to improve withdrawal flushing in `Watcher`
    - Previously withdrawals in an L2 miniblock are only processed once any withdrawal in a later block is received or when the L2 event subscription restarts => the last withdrawal and all withdrawals in the same L2 miniblock will not be processed until the L2 event subscription restarts.